### PR TITLE
FIX sale_available integration with delivery

### DIFF
--- a/website_sale_available/controllers/website_sale_available.py
+++ b/website_sale_available/controllers/website_sale_available.py
@@ -14,7 +14,7 @@ class controller(website_sale):
         order = request.website.sale_get_order(context=request.context)
         if not all([
                 line.product_uom_qty <= line.product_id.virtual_available
-                for line in order.order_line
+                for line in order.order_line if not line.is_delivery
         ]):
             return request.redirect("/shop/cart")
         return res


### PR DESCRIPTION
### Steps to reproduce
Install website_sale_delivery and website_sale_available.
Try to make a website order, when you try to go to payment from checkout you are redirected to cart.

### Issue:
Delivery products are added automatically to order, they are services and they are with stock zero. Stock check on confirm_order send you back to "order"

### Proposed solution:
Only check lines that are not delivery lines

### Further improovements suggested (not yet done)
Perhups we should only check stock for "Stockable Product". This should be modify on confirm_order method and on order view