### PR TITLE
FIX webiste_sale_suggest_create_account with website_sale_clear_cart

### DIFF
--- a/website_sale_clear_cart/website_sale_clear_cart_views.xml
+++ b/website_sale_clear_cart/website_sale_clear_cart_views.xml
@@ -2,7 +2,7 @@
 <openerp>
     <data>
         <template id="clear_cart" inherit_id="website_sale.cart" customize_show="True" name="Clear Cart Button" priority="32" >
-        <xpath expr="//a[@t-if='not optional_products and website_sale_order and website_sale_order.website_order_line']" position="before">
+        <xpath expr="//a[@href='/shop/checkout']" position="before">
                 <t t-if="website_sale_order and website_sale_order.website_order_line">
                     <a href="" id="clear_cart_button" class="btn btn-default mb32"><span class="fa fa-trash-o"/> Clear Cart</a>
                 </t>


### PR DESCRIPTION
### Steps to reproduce
Install website_sale_clear_cart and website_sale_suggest_create_account.

### Issue:
Yo get an error because the t-if path used to add delete clear cart button is modify by website_sale_suggest_create_account

### Proposed solution:
Use expr="//a[@href='/shop/checkout']" instead. Is the same odoo use for eg. here https://github.com/odoo/odoo/blob/8.0/addons/website_sale/views/templates.xml#L806

Thanks!