### PR TITLE
[LINT]

### DIFF
--- a/website_sale_available/README.rst
+++ b/website_sale_available/README.rst
@@ -5,4 +5,4 @@ TODO
 ----
 * Check quantity for "Stockable Product" only. See `#104 <https://github.com/it-projects-llc/website-addons/pull/104>`__
 
-Tested on Odoo 8.0 6682bde8a202794740b9756542b5b119db7606f3
+Tested on Odoo 9.0 aa09c522053b8c91dea557f9e9e71be2f4e965be

--- a/website_sale_available/controllers/website_sale_available.py
+++ b/website_sale_available/controllers/website_sale_available.py
@@ -1,20 +1,16 @@
 # -*- coding: utf-8 -*-
-from openerp import http
 from openerp.http import request
 
-import logging 
-
-_logger = logging.getLogger(__name__)
+import logging
 
 from openerp.addons.website_sale.controllers.main import website_sale
+
+_logger = logging.getLogger(__name__)
 
 
 class Controller(website_sale):
 
-
     def checkout_redirection(self, order):
-        cr, uid, context, registry = request.cr, request.uid, request.context, request.registry
-
         res = super(Controller, self).checkout_redirection(order=order)
         order = request.website.sale_get_order(context=request.context)
 
@@ -23,6 +19,5 @@ class Controller(website_sale):
                 for line in order.order_line if not line.is_delivery
         ]):
             return request.redirect("/shop/cart")
-        
+
         return res
-    


### PR DESCRIPTION
======== Testing test_flake8 ========
website_sale_available/controllers/website_sale_available.py:2:1: F401 'openerp.http' imported but unused
website_sale_available/controllers/website_sale_available.py:5:15: W291 trailing whitespace
website_sale_available/controllers/website_sale_available.py:9:1: E402 module level import not at top of file
website_sale_available/controllers/website_sale_available.py:15:5: E303 too many blank lines (2)
website_sale_available/controllers/website_sale_available.py:16:9: F841 local variable 'cr' is assigned to but never used
website_sale_available/controllers/website_sale_available.py:16:13: F841 local variable 'uid' is assigned to but never used
website_sale_available/controllers/website_sale_available.py:16:18: F841 local variable 'context' is assigned to but never used
website_sale_available/controllers/website_sale_available.py:16:27: F841 local variable 'registry' is assigned to but never used
website_sale_available/controllers/website_sale_available.py:26:1: W293 blank line contains whitespace
website_sale_available/controllers/website_sale_available.py:28:1: W293 blank line contains whitespace
website_sale_available/controllers/website_sale_available.py:28:1: W391 blank line at end of file