### PR TITLE
Don't autoinstall modules

### DIFF
--- a/website_debranding/__manifest__.py
+++ b/website_debranding/__manifest__.py
@@ -13,6 +13,6 @@
     'data': [
         'views.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
     'installable': True
 }

--- a/website_sale_checkout_store/__manifest__.py
+++ b/website_sale_checkout_store/__manifest__.py
@@ -23,5 +23,5 @@
         'data/data.xml',
     ],
     'installable': True,
-    'auto_install': True,
+    'auto_install': False,
 }


### PR DESCRIPTION
Removes the Autoinstall flag from Modules, which have gotten odoo 11 compatibility since the version we already had in the nostraterra project.