### PR TITLE
:zap: real multi-website eCommerce (#335)

### DIFF
--- a/website_multi_company_sale/__manifest__.py
+++ b/website_multi_company_sale/__manifest__.py
@@ -4,7 +4,7 @@
     "category": "eCommerce",
     "live_test_url": "http://apps.it-projects.info/shop/product/website-multi-company?version=11.0",
     "images": ["images/website_multi_company_sale_main.png"],
-    "version": "11.0.1.2.1",
+    "version": "11.0.1.3.0",
     "application": False,
 
     "author": "IT-Projects LLC, Ivan Yelizariev",
@@ -25,6 +25,7 @@
         "views/website_views.xml",
         "views/product_template_views.xml",
         "views/payment_views.xml",
+        "views/sale_views.xml",
         "security/website_multi_company_sale_security.xml",
         "data/default_theme_data.xml",
     ],

--- a/website_multi_company_sale/doc/changelog.rst
+++ b/website_multi_company_sale/doc/changelog.rst
@@ -1,3 +1,10 @@
+`1.3.0`
+-------
+
+- **Add:** Users with ``Current Backend Website`` specified have access only to sale orders from that website
+- **Fix:** When user is logged in on different websites, he can use shopping carts on each websites independently
+- **Improvement:** group sale orders by website
+
 `1.2.1`
 -------
 

--- a/website_multi_company_sale/models/sale_order.py
+++ b/website_multi_company_sale/models/sale_order.py
@@ -9,16 +9,27 @@ class Website(models.Model):
     def sale_get_order(self, force_create=False, code=None, update_pricelist=False, force_pricelist=False):
         company = request.website.company_id
         if not request.session.get('sale_order_id'):
-            # original sale_get_order uses last_website_so_id only when there is
+            # original sale_get_order uses last_website_so_id only when there is no
             # sale_order_id in the session
 
             # company.id seems to be the same as self.id, but let's use variant
             # from original sale_get_order
             self = self.with_context(force_company=company.id)
-        return super(Website, self).sale_get_order(force_create, code, update_pricelist, force_pricelist)
+        sale_order = super(Website, self).sale_get_order(force_create, code, update_pricelist, force_pricelist)
+
+        if sale_order and force_create:
+            sale_order.website_id = self.id
+
+        return sale_order
 
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    last_website_so_id = fields.Many2one(company_dependent=True)
+    last_website_so_id = fields.Many2one(company_dependent=True, website_dependent=True)
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    website_id = fields.Many2one('website', 'Online Order Website', readonly=True)

--- a/website_multi_company_sale/security/website_multi_company_sale_security.xml
+++ b/website_multi_company_sale/security/website_multi_company_sale_security.xml
@@ -12,4 +12,10 @@
     <field name="domain_force">['|', ('website_ids', 'in', [website_id]), ('website_ids', '=', False)]</field>
     <field name="backend_behaviour">true</field>
   </record>
+  <record id="website_multi_company_sale_order_all" model="ir.rule">
+    <field name="name">Users with backend_website_id field specified have access only for sale orders from specied website</field>
+    <field name="model_id" ref="model_sale_order"/>
+    <field name="domain_force">[('website_id', 'in', [user.backend_website_id.id])]</field>
+    <field name="backend_behaviour">true</field>
+  </record>
 </odoo>

--- a/website_multi_company_sale/tests/__init__.py
+++ b/website_multi_company_sale/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_sale_get_order

--- a/website_multi_company_sale/tests/test_sale_get_order.py
+++ b/website_multi_company_sale/tests/test_sale_get_order.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+import urllib
+
+import odoo.tests
+from odoo.tests.common import PORT, HttpCase, get_db_name
+from odoo import api
+
+
+@odoo.tests.common.at_install(True)
+@odoo.tests.common.post_install(True)
+class TestSaleGetOrder(HttpCase):
+
+    def setUp(self):
+        super(TestSaleGetOrder, self).setUp()
+
+    def test_sale_get_order(self):
+        phantom_env = api.Environment(self.registry.test_cr, self.uid, {})
+
+        website1 = phantom_env.ref('website.default_website')
+        website1.domain = '127.0.0.1'
+        website2 = phantom_env.ref('website.website2')
+        website2.domain = 'localhost'
+
+        product_template = phantom_env.ref('product.product_product_11_product_template')
+        product_attribute = phantom_env.ref('product.product_attribute_1')
+        product_attribute_value = phantom_env.ref('product.product_attribute_value_1')
+        attribute = 'attribute-%s-%s' % (product_template.id, product_attribute.id)
+        form_data = {
+            'product_id': product_template.id,
+            attribute: product_attribute_value.id,
+            'add_qty': 1,
+        }
+        data = urllib.urlencode(form_data)
+
+        login = "demo"
+        self.authenticate(login, login)
+
+        count_so_before = phantom_env['sale.order'].sudo().search_count([])
+
+        response = self.url_open("http://127.0.0.1:%d/shop/cart/update" % PORT, data=data, timeout=60)
+        self.assertEqual(response.getcode(), 200)
+        so_last = phantom_env['sale.order'].search([], limit=1)
+        self.assertEqual(so_last.website_id, website1)
+
+        # setup a magic session_id that will be rollbacked
+        self.session = odoo.http.root.session_store.new()
+        self.session_id = self.session.sid
+        self.session.db = get_db_name()
+        odoo.http.root.session_store.save(self.session)
+        self.authenticate(login, login)
+
+        headers = dict(self.opener.addheaders)
+        headers['Cookie'] = 'session_id=%s' % self.session_id
+        self.opener.addheaders = headers.items()
+
+        response = self.url_open("http://localhost:%d/shop/cart/update" % PORT, data=data, timeout=60)
+        self.assertEqual(response.getcode(), 200)
+        so_last = phantom_env['sale.order'].search([], limit=1)
+        self.assertEqual(so_last.website_id, website2)
+
+        count_so_after = phantom_env['sale.order'].sudo().search_count([])
+        self.assertEqual(count_so_after, count_so_before+2)

--- a/website_multi_company_sale/views/sale_views.xml
+++ b/website_multi_company_sale/views/sale_views.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="sale_order_view_search_inherit_quotation_inherit_website_multi_company_sale" model="ir.ui.view">
+    <field name="name">sale.order.quotation.view.search.website_multi_company_sale</field>
+    <field name="model">sale.order</field>
+    <field name="inherit_id" ref="sale.sale_order_view_search_inherit_quotation"/>
+    <field name="arch" type="xml">
+      <xpath expr="//filter[@name='sales']" position="after">
+        <group expand="0" string="Group By">
+          <filter string="Website" domain="[]" context="{'group_by':'website_id'}"/>
+        </group>
+      </xpath>
+    </field>
+  </record>
+  <record id="sale_order_view_search_inherit_sale_inherit_website_multi_company_sale" model="ir.ui.view">
+    <field name="name">sale.order.sale.view.search.website_multi_company_sale</field>
+    <field name="model">sale.order</field>
+    <field name="inherit_id" ref="sale.sale_order_view_search_inherit_sale"/>
+    <field name="arch" type="xml">
+      <xpath expr="//filter[@name='sales']" position="after">
+        <group expand="0" string="Group By">
+          <filter string="Website" domain="[]" context="{'group_by':'website_id'}"/>
+        </group>
+      </xpath>
+    </field>
+  </record>
+  <record id="view_order_form_inherit_website_multi_company_sale" model="ir.ui.view">
+    <field name="name">sale.order.form</field>
+    <field name="model">sale.order</field>
+    <field name="inherit_id" ref="sale.view_order_form"/>
+    <field name="arch" type="xml">
+      <xpath expr="//field[@name='company_id']" position="after">
+        <field name="website_id"/>
+      </xpath>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
+- **Add:** Users with ``Current Backend Website`` specified have access only to sale orders from that website
+- **Fix:** When user is logged in on different websites, he can use shopping carts on each websites independently
+- **Improvement:** group sale orders by website