### PR TITLE
[FIX] Issue #389: bad oca_dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-chess
+python-chess<0.24.0


### PR DESCRIPTION
This fixes issue #389 , the python-chess library stopped support for python2 after 0.23.x