### PR TITLE
:shield: python-chess 0.24 doesn't support python2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-chess
+python-chess<0.24


### PR DESCRIPTION
This commit can be reverted in odoo 11+