### PR TITLE
website_multi_company: add security group that allows public users read data from current website's company

### DIFF
--- a/website_multi_company/__manifest__.py
+++ b/website_multi_company/__manifest__.py
@@ -7,7 +7,7 @@
     "category": "eCommerce",
     # "live_test_url": "http://apps.it-projects.info/shop/product/website-multi-company?version=10.0",
     "images": ['images/website_multi_company_main.png'],
-    "version": "10.0.2.0.3",
+    "version": "10.0.2.0.4",
     "application": False,
 
     "author": "IT-Projects LLC, Ivan Yelizariev",
@@ -21,6 +21,7 @@
         "website",
         "website_multi_theme",
         "ir_config_parameter_multi_company",
+        "ir_rule_website",
     ],
     "external_dependencies": {"python": [], "bin": []},
     "data": [
@@ -32,6 +33,7 @@
         "views/website_navbar_templates.xml",
         "views/res_users_view.xml",
         "data/first_action.xml",
+        'security/res_security.xml',
     ],
     "qweb": [
     ],

--- a/website_multi_company/doc/changelog.rst
+++ b/website_multi_company/doc/changelog.rst
@@ -1,3 +1,8 @@
+`2.0.4`
+-------
+
+- **FIX:** Public users now have access to read company logo in a website
+
 `2.0.3`
 -------
 

--- a/website_multi_company/doc/changelog.rst
+++ b/website_multi_company/doc/changelog.rst
@@ -1,7 +1,7 @@
 `2.0.4`
 -------
 
-- **FIX:** Public users now have access to read company logo in a website
+- **FIX:** Non-admin users now have access to read company logo in a website
 
 `2.0.3`
 -------

--- a/website_multi_company/security/res_security.xml
+++ b/website_multi_company/security/res_security.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp><data>
+  <record id="res_company_rule_public_website" model="ir.rule">
+    <field name="name">company rule public website</field>
+    <field name="model_id" ref="base.model_res_company"/>
+    <field eval="False" name="global"/>
+    <field name="groups" eval="[(6, 0, [ref('base.group_public')])]"/>
+    <field name="domain_force">[('id','=', website.company_id.id)]</field>
+  </record>
+</data></openerp>

--- a/website_multi_company/security/res_security.xml
+++ b/website_multi_company/security/res_security.xml
@@ -7,4 +7,11 @@
     <field name="groups" eval="[(6, 0, [ref('base.group_public')])]"/>
     <field name="domain_force">[('id','=', website.company_id.id)]</field>
   </record>
+  <record id="res_company_rule_user_website" model="ir.rule">
+    <field name="name">company rule user website</field>
+    <field name="model_id" ref="base.model_res_company"/>
+    <field eval="False" name="global"/>
+    <field name="groups" eval="[(6, 0, [ref('base.group_user')])]"/>
+    <field name="domain_force">[('id','=', website.company_id.id)]</field>
+  </record>
 </data></openerp>

--- a/website_multi_company_demo/tests/__init__.py
+++ b/website_multi_company_demo/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_domain_updating
+from . import test_website_multi_company

--- a/website_multi_company_demo/tests/test_website_multi_company.py
+++ b/website_multi_company_demo/tests/test_website_multi_company.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from odoo.tests.common import SingleTransactionCase, get_db_name, at_install, post_install
+from ..models.res_users import WEBSITE_REFS
+from odoo.api import Environment
+
+db_name = get_db_name()
+
+
+@at_install(False)
+@post_install(True)
+class TestWebsiteMultiCompany(SingleTransactionCase):
+
+    def _test_website_price_difference_is_accessible(self, env):
+        website = env.ref(WEBSITE_REFS[0])
+        products = env['product.template'].search(
+            [('company_id', '=', website.company_id.id)] +
+            website.sale_product_domain()
+        )
+        product = products[0]
+        product.website_price_difference  # make sure, it does not throw exception
+
+    def test_website_price_difference_is_accessible_for_demo_user(self):
+        uid = self.registry['res.users'].authenticate(db_name, 'demo', 'demo', {})
+        with self.cursor() as cr:
+            env = Environment(cr, uid, {})
+            self._test_website_price_difference_is_accessible(env)
+
+    def test_website_price_difference_is_accessible_for_public_user(self, env=None):
+        self._test_website_price_difference_is_accessible(self.env(user=self.browse_ref('base.public_user')))


### PR DESCRIPTION
Fixes bug, when demo user or public user cannot access example shops from `website_multi_company_demo`, 'cos it shows error 500 and throws exception like `AccessError(u'The requested operation cannot be completed due to security restrictions. Please contact your system administrator...)`

PR is draft, 'cos I need to add test cases.