### PR TITLE
11.0 website multi company add rule for registered users

### DIFF
--- a/website_multi_company/doc/changelog.rst
+++ b/website_multi_company/doc/changelog.rst
@@ -30,6 +30,11 @@
 
 - **New:** Use Website's company for field **Company** on record creation when possible. It affects many models and features
 
+`2.0.5`
+-------
+
+- **Fix:** Non-admin users now have access to read company logo in a website
+
 `2.0.4`
 -------
 

--- a/website_multi_company/security/res_security.xml
+++ b/website_multi_company/security/res_security.xml
@@ -7,4 +7,11 @@
     <field name="groups" eval="[(6, 0, [ref('base.group_public')])]"/>
     <field name="domain_force">[('id','=', website.company_id.id)]</field>
   </record>
+  <record id="res_company_rule_user_website" model="ir.rule">
+    <field name="name">company rule user website</field>
+    <field name="model_id" ref="base.model_res_company"/>
+    <field eval="False" name="global"/>
+    <field name="groups" eval="[(6, 0, [ref('base.group_user')])]"/>
+    <field name="domain_force">[('id','=', website.company_id.id)]</field>
+  </record>
 </odoo>

--- a/website_multi_company_demo/tests/__init__.py
+++ b/website_multi_company_demo/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_domain_updating
+from . import test_website_multi_company

--- a/website_multi_company_demo/tests/test_website_multi_company.py
+++ b/website_multi_company_demo/tests/test_website_multi_company.py
@@ -1,0 +1,29 @@
+from odoo.tests.common import SingleTransactionCase, get_db_name, at_install, post_install
+from ..models.res_users import WEBSITE_REFS
+from odoo.api import Environment
+
+db_name = get_db_name()
+
+
+@at_install(True)
+@post_install(True)
+class TestWebsiteMultiCompany(SingleTransactionCase):
+
+    def _test_website_price_difference_is_accessible(self, env):
+        website = env.ref(WEBSITE_REFS[0])
+        products = env['product.template'].search(
+            [('company_id', '=', website.company_id.id)] +
+            website.sale_product_domain()
+        )
+        product = products[0]
+        # make sure, it does not throw exception
+        product.website_price_difference  # pylint: disable=pointless-statement
+
+    def test_website_price_difference_is_accessible_for_demo_user(self):
+        uid = self.registry['res.users'].authenticate(db_name, 'demo', 'demo', {})
+        with self.cursor() as cr:
+            env = Environment(cr, uid, {})
+            self._test_website_price_difference_is_accessible(env)
+
+    def test_website_price_difference_is_accessible_for_public_user(self):
+        self._test_website_price_difference_is_accessible(self.env(user=self.browse_ref('base.public_user')))


### PR DESCRIPTION
First commit is the same as https://github.com/it-projects-llc/website-addons/pull/433/commits/69c35ad4b16cc7742d9a67c849a0382f51fde34b from https://github.com/it-projects-llc/website-addons/pull/433/ but adds new entry in changelog, instead of editing existing one.

PR is draft, 'cos `test_website_price_difference_is_accessible_for_demo_user` fails, but it is copy of existing test from https://github.com/it-projects-llc/website-addons/pull/433/